### PR TITLE
BUGS-6518 Allow greater range of characters in full text search

### DIFF
--- a/lib/pg_search_scope/model_helper.rb
+++ b/lib/pg_search_scope/model_helper.rb
@@ -58,7 +58,7 @@ module PgSearchScope
         options = scope_options.merge(options || {})
         search_string ||= ''
 
-        terms = search_string.scan(/([\p{Lu}\p{Ll}\d][\p{Lu}\p{Ll}\d\.'@]*)/u).map {|s,_| s.gsub /'/, "''"}
+        terms = search_string.scan(/([\p{Lu}\p{Ll}\d][\p{Graph}]*)/u).map {|s,_| s.gsub /'/, "''"}
 
         search_scope = send(SCOPE_METHOD)
 


### PR DESCRIPTION
Originally, only alphanumerics could be searched, with a few explicitly
defined non-starting symbols. This expands the range of non-starting
symbols to any non-whitespace character.